### PR TITLE
mock out ItemGroupExtensions

### DIFF
--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/item/group/ItemGroupExtensions.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/item/group/ItemGroupExtensions.java
@@ -1,0 +1,7 @@
+package net.fabricmc.fabric.impl.item.group;
+
+public interface ItemGroupExtensions extends org.quiltmc.qsl.item.group.impl.ItemGroupExtensions {
+    default void faric_expandArray() {
+        quilt$expandArray();
+    }
+}

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/item/group/ItemGroupExtensions.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/item/group/ItemGroupExtensions.java
@@ -17,7 +17,7 @@
 package net.fabricmc.fabric.impl.item.group;
 
 public interface ItemGroupExtensions extends org.quiltmc.qsl.item.group.impl.ItemGroupExtensions {
-    default void fabric_expandArray() {
-        quilt$expandArray();
-    }
+	default void fabric_expandArray() {
+		this.quilt$expandArray();
+	}
 }

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/item/group/ItemGroupExtensions.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/item/group/ItemGroupExtensions.java
@@ -1,7 +1,7 @@
 package net.fabricmc.fabric.impl.item.group;
 
 public interface ItemGroupExtensions extends org.quiltmc.qsl.item.group.impl.ItemGroupExtensions {
-    default void faric_expandArray() {
+    default void fabric_expandArray() {
         quilt$expandArray();
     }
 }

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/item/group/ItemGroupExtensions.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/item/group/ItemGroupExtensions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.item.group;
 
 public interface ItemGroupExtensions extends org.quiltmc.qsl.item.group.impl.ItemGroupExtensions {


### PR DESCRIPTION
Right now, Fabric API has no good way to extend item groups. This is a bit of an API design issue, and the only real way around it is for people to implement `ItemGroupExtensions` on their own.

This PR mocks out fabric's `ItemGroupExtensions` to fix mods that depend on this behavior. We shouldn't have to, but here we are.

I sketched this out in Codespaces bc I'm on the go so it's missing license headers and stuff. I'll add those in in a bit.