### PR TITLE
Fix item group extensions

### DIFF
--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/item/group/ItemGroupExtensions.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/impl/item/group/ItemGroupExtensions.java
@@ -1,0 +1,7 @@
+package net.fabricmc.fabric.impl.item.group;
+
+public interface ItemGroupExtensions extends org.quiltmc.qsl.item.group.impl.ItemGroupExtensions {
+    default void faric_expandArray() {
+        quilt$expandArray();
+    }
+}

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/mixin/item/group/ItemGroupMixin.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/mixin/item/group/ItemGroupMixin.java
@@ -24,4 +24,4 @@ import net.fabricmc.fabric.impl.item.group.ItemGroupExtensions;
 
 //this should be all that's necessary to monkeypatch ItemGroupExtensions back onto ItemGroup!
 @Mixin(ItemGroup.class)
-public class MixinItemGroup implements ItemGroupExtensions {}
+public class ItemGroupMixin implements ItemGroupExtensions {}

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/mixin/item/group/MixinItemGroup.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/mixin/item/group/MixinItemGroup.java
@@ -1,0 +1,2 @@
+package net.fabricmc.fabric.mixin.item.group;
+

--- a/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/mixin/item/group/MixinItemGroup.java
+++ b/fabric-item-groups-v0/src/main/java/net/fabricmc/fabric/mixin/item/group/MixinItemGroup.java
@@ -1,2 +1,27 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.item.group;
 
+import org.spongepowered.asm.mixin.Mixin;
+
+import net.minecraft.item.ItemGroup;
+
+import net.fabricmc.fabric.impl.item.group.ItemGroupExtensions;
+
+//this should be all that's necessary to monkeypatch ItemGroupExtensions back onto ItemGroup!
+@Mixin(ItemGroup.class)
+public class MixinItemGroup implements ItemGroupExtensions {}

--- a/fabric-item-groups-v0/src/main/resources/fabric-item-groups-v0.mixins.json
+++ b/fabric-item-groups-v0/src/main/resources/fabric-item-groups-v0.mixins.json
@@ -1,0 +1,11 @@
+{
+    "required": true,
+    "package": "net.fabricmc.fabric.mixin.item.group",
+    "compatibilityLevel": "JAVA_17",
+    "mixins": [
+      "ItemGroupMixin"
+    ],
+    "injectors": {
+      "defaultRequire": 1
+    }
+  }

--- a/fabric-item-groups-v0/src/main/resources/fabric.mod.json
+++ b/fabric-item-groups-v0/src/main/resources/fabric.mod.json
@@ -19,6 +19,9 @@
     "FabricMC",
     "QuiltMC"
   ],
+  "mixins": [
+    "fabric-item-groups-v0.mixins.json"
+  ],
   "depends": {
     "fabricloader": ">=0.6.0",
     "minecraft": ">=1.15-",


### PR DESCRIPTION
UNTESTED UNTESTED UNTESTED THIS IS UNTESTED

sorry this commit history is a mess something went *very* wrong with my git while I was committing it

fixes an issue with my previous PR where ItemGroupExtensions wasn't actually mixed onto ItemGroup, causing the monkeypatch to not work