### PR TITLE
Work around the usage of unregistered entries on content registries through deferring queues

### DIFF
--- a/codeformat/checkstyle.xml
+++ b/codeformat/checkstyle.xml
@@ -194,7 +194,7 @@
 			- largely unconstained trailing subpackages
 			-->
 			<property name="format"
-			value="^net\.fabricmc\.fabric\.(api(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+([a-rt-z]|ss))+\.v[1-9][0-9]*|(impl|mixin|test)(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+([a-rt-z]|ss))+(\.v[1-9][0-9]*)?|api\.(event|util|biomes\.v1|registry|client\.screen|container|block|entity|client\.itemgroup|client\.keybinding|tag|tools|client\.model|network|server|client\.render|resource|client\.texture))(|\.[a-z]+(\.[a-z0-9]+)*)$"/>
+			value="^(org\.quiltmc\.quilted_fabric_api|net\.fabricmc\.fabric)\.(api(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+([a-rt-z]|ss))+\.v[1-9][0-9]*|(impl|mixin|test)(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+([a-rt-z]|ss))+(\.v[1-9][0-9]*)?|api\.(event|util|biomes\.v1|registry|client\.screen|container|block|entity|client\.itemgroup|client\.keybinding|tag|tools|client\.model|network|server|client\.render|resource|client\.texture))(|\.[a-z]+(\.[a-z0-9]+)*)$"/>
 		</module>
 
 		<!--<module name="InvalidJavadocPosition"/>-->

--- a/fabric-content-registries-v0/build.gradle
+++ b/fabric-content-registries-v0/build.gradle
@@ -5,6 +5,7 @@ upstream_version = getSubprojectUpstreamVersion(project)
 dependencies {
 	modApi(getQslModule("block", "block_content_registry"))
 	modApi(getQslModule("item", "item_content_registry"))
+	modApi(getQslModule("core", "registry"))
 }
 
 moduleDependencies(project, [

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/FlattenableBlockRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/FlattenableBlockRegistry.java
@@ -27,14 +27,12 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 
 import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
 
 /**
  * A registry for shovel flattening interactions. A vanilla example is turning dirt to dirt paths.
  */
 @Deprecated
 public final class FlattenableBlockRegistry {
-	private static final DeferringQueue<Block, BlockState> QUEUE = QuiltDeferringQueues.BLOCK.register(BlockContentRegistries.FLATTENABLE_BLOCK);
 	private static final Logger LOGGER = LoggerFactory.getLogger(FlattenableBlockRegistry.class);
 
 	private FlattenableBlockRegistry() {
@@ -54,6 +52,6 @@ public final class FlattenableBlockRegistry {
 			LOGGER.debug("Replaced old flattening mapping from {} to {} with {}", input, old, flattened);
 		});
 
-		QuiltDeferringQueues.BLOCK.addEntry(QUEUE, input, flattened);
+		QuiltDeferringQueues.addEntry(BlockContentRegistries.FLATTENABLE_BLOCK, input, flattened);
 	}
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/FlattenableBlockRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/FlattenableBlockRegistry.java
@@ -26,11 +26,15 @@ import org.slf4j.Logger;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
+
 /**
  * A registry for shovel flattening interactions. A vanilla example is turning dirt to dirt paths.
  */
 @Deprecated
 public final class FlattenableBlockRegistry {
+	private static final DeferringQueue<Block, BlockState> QUEUE = QuiltDeferringQueues.BLOCK.register(BlockContentRegistries.FLATTENABLE_BLOCK);
 	private static final Logger LOGGER = LoggerFactory.getLogger(FlattenableBlockRegistry.class);
 
 	private FlattenableBlockRegistry() {
@@ -50,6 +54,6 @@ public final class FlattenableBlockRegistry {
 			LOGGER.debug("Replaced old flattening mapping from {} to {} with {}", input, old, flattened);
 		});
 
-		BlockContentRegistries.FLATTENABLE_BLOCK.put(input, flattened);
+		QuiltDeferringQueues.BLOCK.addEntry(QUEUE, input, flattened);
 	}
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/FlattenableBlockRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/FlattenableBlockRegistry.java
@@ -21,12 +21,11 @@ import java.util.Objects;
 
 import org.slf4j.LoggerFactory;
 import org.quiltmc.qsl.block.content.registry.api.BlockContentRegistries;
+import org.quiltmc.quilted_fabric_api.impl.content.registry.util.QuiltDeferringQueues;
 import org.slf4j.Logger;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
 
 /**
  * A registry for shovel flattening interactions. A vanilla example is turning dirt to dirt paths.

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/OxidizableBlocksRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/OxidizableBlocksRegistry.java
@@ -24,10 +24,16 @@ import org.quiltmc.qsl.block.content.registry.api.ReversibleBlockEntry;
 
 import net.minecraft.block.Block;
 
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
+
 /**
  * Provides methods for registering oxidizable and waxable blocks.
  */
 public final class OxidizableBlocksRegistry {
+	private static final DeferringQueue<Block, ReversibleBlockEntry> OXIDIZABLE_QUEUE = QuiltDeferringQueues.BLOCK.register(BlockContentRegistries.OXIDIZABLE_BLOCK);
+	private static final DeferringQueue<Block, ReversibleBlockEntry> WAXABLE_QUEUE = QuiltDeferringQueues.BLOCK.register(BlockContentRegistries.WAXABLE_BLOCK);
+
 	private OxidizableBlocksRegistry() {
 	}
 
@@ -40,7 +46,7 @@ public final class OxidizableBlocksRegistry {
 	public static void registerOxidizableBlockPair(Block less, Block more) {
 		Objects.requireNonNull(less, "Oxidizable block cannot be null!");
 		Objects.requireNonNull(more, "Oxidizable block cannot be null!");
-		BlockContentRegistries.OXIDIZABLE_BLOCK.put(less, new ReversibleBlockEntry(more, true));
+		QuiltDeferringQueues.BLOCK.addEntry(OXIDIZABLE_QUEUE, less, new ReversibleBlockEntry(more, true));
 	}
 
 	/**
@@ -52,6 +58,6 @@ public final class OxidizableBlocksRegistry {
 	public static void registerWaxableBlockPair(Block unwaxed, Block waxed) {
 		Objects.requireNonNull(unwaxed, "Unwaxed block cannot be null!");
 		Objects.requireNonNull(waxed, "Waxed block cannot be null!");
-		BlockContentRegistries.WAXABLE_BLOCK.put(unwaxed, new ReversibleBlockEntry(waxed, true));
+		QuiltDeferringQueues.BLOCK.addEntry(WAXABLE_QUEUE, unwaxed, new ReversibleBlockEntry(waxed, true));
 	}
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/OxidizableBlocksRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/OxidizableBlocksRegistry.java
@@ -21,10 +21,9 @@ import java.util.Objects;
 
 import org.quiltmc.qsl.block.content.registry.api.BlockContentRegistries;
 import org.quiltmc.qsl.block.content.registry.api.ReversibleBlockEntry;
+import org.quiltmc.quilted_fabric_api.impl.content.registry.util.QuiltDeferringQueues;
 
 import net.minecraft.block.Block;
-
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
 
 /**
  * Provides methods for registering oxidizable and waxable blocks.

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/OxidizableBlocksRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/OxidizableBlocksRegistry.java
@@ -25,15 +25,11 @@ import org.quiltmc.qsl.block.content.registry.api.ReversibleBlockEntry;
 import net.minecraft.block.Block;
 
 import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
 
 /**
  * Provides methods for registering oxidizable and waxable blocks.
  */
 public final class OxidizableBlocksRegistry {
-	private static final DeferringQueue<Block, ReversibleBlockEntry> OXIDIZABLE_QUEUE = QuiltDeferringQueues.BLOCK.register(BlockContentRegistries.OXIDIZABLE_BLOCK);
-	private static final DeferringQueue<Block, ReversibleBlockEntry> WAXABLE_QUEUE = QuiltDeferringQueues.BLOCK.register(BlockContentRegistries.WAXABLE_BLOCK);
-
 	private OxidizableBlocksRegistry() {
 	}
 
@@ -46,7 +42,7 @@ public final class OxidizableBlocksRegistry {
 	public static void registerOxidizableBlockPair(Block less, Block more) {
 		Objects.requireNonNull(less, "Oxidizable block cannot be null!");
 		Objects.requireNonNull(more, "Oxidizable block cannot be null!");
-		QuiltDeferringQueues.BLOCK.addEntry(OXIDIZABLE_QUEUE, less, new ReversibleBlockEntry(more, true));
+		QuiltDeferringQueues.addEntry(BlockContentRegistries.OXIDIZABLE_BLOCK, less, new ReversibleBlockEntry(more, true));
 	}
 
 	/**
@@ -58,6 +54,6 @@ public final class OxidizableBlocksRegistry {
 	public static void registerWaxableBlockPair(Block unwaxed, Block waxed) {
 		Objects.requireNonNull(unwaxed, "Unwaxed block cannot be null!");
 		Objects.requireNonNull(waxed, "Waxed block cannot be null!");
-		QuiltDeferringQueues.BLOCK.addEntry(WAXABLE_QUEUE, unwaxed, new ReversibleBlockEntry(waxed, true));
+		QuiltDeferringQueues.addEntry(BlockContentRegistries.WAXABLE_BLOCK, unwaxed, new ReversibleBlockEntry(waxed, true));
 	}
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/SculkSensorFrequencyRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/SculkSensorFrequencyRegistry.java
@@ -18,13 +18,12 @@
 package net.fabricmc.fabric.api.registry;
 
 import org.quiltmc.qsl.block.content.registry.api.BlockContentRegistries;
+import org.quiltmc.quilted_fabric_api.impl.content.registry.util.QuiltDeferringQueues;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.minecraft.tag.GameEventTags;
 import net.minecraft.world.event.GameEvent;
-
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
 
 /**
  * Provides a method for registering sculk sensor frequencies.

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/SculkSensorFrequencyRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/SculkSensorFrequencyRegistry.java
@@ -24,10 +24,14 @@ import org.slf4j.LoggerFactory;
 import net.minecraft.tag.GameEventTags;
 import net.minecraft.world.event.GameEvent;
 
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
+
 /**
  * Provides a method for registering sculk sensor frequencies.
  */
 public final class SculkSensorFrequencyRegistry {
+	private static final DeferringQueue<GameEvent, Integer> QUEUE = QuiltDeferringQueues.GAME_EVENT.register(BlockContentRegistries.SCULK_FREQUENCY);
 	private static final Logger LOGGER = LoggerFactory.getLogger(SculkSensorFrequencyRegistry.class);
 
 	private SculkSensorFrequencyRegistry() {
@@ -55,6 +59,6 @@ public final class SculkSensorFrequencyRegistry {
 			LOGGER.debug("Replaced old frequency mapping for {} - was {}, now {}", event.getId(), replaced, frequency);
 		});
 
-		BlockContentRegistries.SCULK_FREQUENCY.put(event, frequency);
+		QuiltDeferringQueues.GAME_EVENT.addEntry(QUEUE, event, frequency);
 	}
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/SculkSensorFrequencyRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/SculkSensorFrequencyRegistry.java
@@ -25,13 +25,11 @@ import net.minecraft.tag.GameEventTags;
 import net.minecraft.world.event.GameEvent;
 
 import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
 
 /**
  * Provides a method for registering sculk sensor frequencies.
  */
 public final class SculkSensorFrequencyRegistry {
-	private static final DeferringQueue<GameEvent, Integer> QUEUE = QuiltDeferringQueues.GAME_EVENT.register(BlockContentRegistries.SCULK_FREQUENCY);
 	private static final Logger LOGGER = LoggerFactory.getLogger(SculkSensorFrequencyRegistry.class);
 
 	private SculkSensorFrequencyRegistry() {
@@ -59,6 +57,6 @@ public final class SculkSensorFrequencyRegistry {
 			LOGGER.debug("Replaced old frequency mapping for {} - was {}, now {}", event.getId(), replaced, frequency);
 		});
 
-		QuiltDeferringQueues.GAME_EVENT.addEntry(QUEUE, event, frequency);
+		QuiltDeferringQueues.addEntry(BlockContentRegistries.SCULK_FREQUENCY, event, frequency);
 	}
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/StrippableBlockRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/StrippableBlockRegistry.java
@@ -21,12 +21,11 @@ import java.util.Objects;
 
 import org.slf4j.LoggerFactory;
 import org.quiltmc.qsl.block.content.registry.api.BlockContentRegistries;
+import org.quiltmc.quilted_fabric_api.impl.content.registry.util.QuiltDeferringQueues;
 import org.slf4j.Logger;
 
 import net.minecraft.block.Block;
 import net.minecraft.state.property.Properties;
-
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
 
 /**
  * A registry for axe stripping interactions. A vanilla example is turning logs to stripped logs.

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/StrippableBlockRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/StrippableBlockRegistry.java
@@ -27,13 +27,11 @@ import net.minecraft.block.Block;
 import net.minecraft.state.property.Properties;
 
 import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
 
 /**
  * A registry for axe stripping interactions. A vanilla example is turning logs to stripped logs.
  */
 public final class StrippableBlockRegistry {
-	private static final DeferringQueue<Block, Block> QUEUE = QuiltDeferringQueues.BLOCK.register(BlockContentRegistries.STRIPPABLE_BLOCK);
 	private static final Logger LOGGER = LoggerFactory.getLogger(StrippableBlockRegistry.class);
 
 	private StrippableBlockRegistry() {
@@ -56,7 +54,7 @@ public final class StrippableBlockRegistry {
 			LOGGER.debug("Replaced old stripping mapping from {} to {} with {}", input, old, stripped);
 		});
 
-		QuiltDeferringQueues.BLOCK.addEntry(QUEUE, input, stripped);
+		QuiltDeferringQueues.addEntry(BlockContentRegistries.STRIPPABLE_BLOCK, input, stripped);
 	}
 
 	private static void requireNonNullAndAxisProperty(Block block, String name) {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/StrippableBlockRegistry.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/api/registry/StrippableBlockRegistry.java
@@ -26,10 +26,14 @@ import org.slf4j.Logger;
 import net.minecraft.block.Block;
 import net.minecraft.state.property.Properties;
 
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
+
 /**
  * A registry for axe stripping interactions. A vanilla example is turning logs to stripped logs.
  */
 public final class StrippableBlockRegistry {
+	private static final DeferringQueue<Block, Block> QUEUE = QuiltDeferringQueues.BLOCK.register(BlockContentRegistries.STRIPPABLE_BLOCK);
 	private static final Logger LOGGER = LoggerFactory.getLogger(StrippableBlockRegistry.class);
 
 	private StrippableBlockRegistry() {
@@ -52,7 +56,7 @@ public final class StrippableBlockRegistry {
 			LOGGER.debug("Replaced old stripping mapping from {} to {} with {}", input, old, stripped);
 		});
 
-		BlockContentRegistries.STRIPPABLE_BLOCK.put(input, stripped);
+		QuiltDeferringQueues.BLOCK.addEntry(QUEUE, input, stripped);
 	}
 
 	private static void requireNonNullAndAxisProperty(Block block, String name) {

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/CompostingChanceRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/CompostingChanceRegistryImpl.java
@@ -25,11 +25,8 @@ import net.minecraft.item.ItemConvertible;
 
 import net.fabricmc.fabric.api.registry.CompostingChanceRegistry;
 import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
 
 public class CompostingChanceRegistryImpl implements CompostingChanceRegistry {
-	private static final DeferringQueue<Item, Float> QUEUE = QuiltDeferringQueues.ITEM.register(ItemContentRegistries.COMPOST_CHANCE);
-
 	@Override
 	public Float get(ItemConvertible item) {
 		return ItemContentRegistries.COMPOST_CHANCE.get(item.asItem()).orElse(0.0F);
@@ -37,7 +34,7 @@ public class CompostingChanceRegistryImpl implements CompostingChanceRegistry {
 
 	@Override
 	public void add(ItemConvertible item, Float value) {
-		QuiltDeferringQueues.ITEM.addEntry(QUEUE, item.asItem(), value);
+		QuiltDeferringQueues.addEntry(ItemContentRegistries.COMPOST_CHANCE, item.asItem(), value);
 	}
 
 	/**

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/CompostingChanceRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/CompostingChanceRegistryImpl.java
@@ -28,7 +28,7 @@ import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
 import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
 
 public class CompostingChanceRegistryImpl implements CompostingChanceRegistry {
-	private static final DeferringQueue<Item, Float> QUEUE = QuiltDeferringQueues.ITEM_DEFERRING_QUEUES.registerQueue(ItemContentRegistries.COMPOST_CHANCE);
+	private static final DeferringQueue<Item, Float> QUEUE = QuiltDeferringQueues.ITEM.register(ItemContentRegistries.COMPOST_CHANCE);
 
 	@Override
 	public Float get(ItemConvertible item) {
@@ -37,7 +37,7 @@ public class CompostingChanceRegistryImpl implements CompostingChanceRegistry {
 
 	@Override
 	public void add(ItemConvertible item, Float value) {
-		QuiltDeferringQueues.ITEM_DEFERRING_QUEUES.addEntry(QUEUE, item.asItem(), value);
+		QuiltDeferringQueues.ITEM.addEntry(QUEUE, item.asItem(), value);
 	}
 
 	/**

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/CompostingChanceRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/CompostingChanceRegistryImpl.java
@@ -18,13 +18,13 @@
 package net.fabricmc.fabric.impl.content.registry;
 
 import org.quiltmc.qsl.item.content.registry.api.ItemContentRegistries;
+import org.quiltmc.quilted_fabric_api.impl.content.registry.util.QuiltDeferringQueues;
 
 import net.minecraft.tag.TagKey;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
 
 import net.fabricmc.fabric.api.registry.CompostingChanceRegistry;
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
 
 public class CompostingChanceRegistryImpl implements CompostingChanceRegistry {
 	@Override

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/CompostingChanceRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/CompostingChanceRegistryImpl.java
@@ -24,8 +24,12 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
 
 import net.fabricmc.fabric.api.registry.CompostingChanceRegistry;
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
 
 public class CompostingChanceRegistryImpl implements CompostingChanceRegistry {
+	private static final DeferringQueue<Item, Float> QUEUE = QuiltDeferringQueues.ITEM_DEFERRING_QUEUES.registerQueue(ItemContentRegistries.COMPOST_CHANCE);
+
 	@Override
 	public Float get(ItemConvertible item) {
 		return ItemContentRegistries.COMPOST_CHANCE.get(item.asItem()).orElse(0.0F);
@@ -33,7 +37,7 @@ public class CompostingChanceRegistryImpl implements CompostingChanceRegistry {
 
 	@Override
 	public void add(ItemConvertible item, Float value) {
-		ItemContentRegistries.COMPOST_CHANCE.put(item.asItem(), value);
+		QuiltDeferringQueues.ITEM_DEFERRING_QUEUES.addEntry(QUEUE, item.asItem(), value);
 	}
 
 	/**

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FlammableBlockRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FlammableBlockRegistryImpl.java
@@ -17,9 +17,6 @@
 
 package net.fabricmc.fabric.impl.content.registry;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.quiltmc.qsl.block.content.registry.api.BlockContentRegistries;
 import org.quiltmc.qsl.block.content.registry.api.FlammableBlockEntry;
 
@@ -27,10 +24,11 @@ import net.minecraft.block.Block;
 import net.minecraft.tag.TagKey;
 
 import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
 
 public class FlammableBlockRegistryImpl implements FlammableBlockRegistry {
-	private static final FlammableBlockEntry REMOVED = new FlammableBlockEntry(0, 0);
-	private static final Map<Block, FlammableBlockRegistryImpl> REGISTRIES = new HashMap<>();
+	private static final DeferringQueue<Block, FlammableBlockEntry> QUEUE = QuiltDeferringQueues.BLOCK.register(BlockContentRegistries.FLAMMABLE_BLOCK);
 
 	private FlammableBlockRegistryImpl(Block key) { }
 
@@ -50,7 +48,7 @@ public class FlammableBlockRegistryImpl implements FlammableBlockRegistry {
 
 	@Override
 	public void add(Block block, Entry value) {
-		BlockContentRegistries.FLAMMABLE_BLOCK.put(block, value.toQuilt());
+		QuiltDeferringQueues.BLOCK.addEntry(QUEUE, block, value.toQuilt());
 	}
 
 	@Override

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FlammableBlockRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FlammableBlockRegistryImpl.java
@@ -25,11 +25,8 @@ import net.minecraft.tag.TagKey;
 
 import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
 import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
 
 public class FlammableBlockRegistryImpl implements FlammableBlockRegistry {
-	private static final DeferringQueue<Block, FlammableBlockEntry> QUEUE = QuiltDeferringQueues.BLOCK.register(BlockContentRegistries.FLAMMABLE_BLOCK);
-
 	private FlammableBlockRegistryImpl(Block key) { }
 
 	// User-facing fire registry interface - queries vanilla fire block
@@ -48,7 +45,7 @@ public class FlammableBlockRegistryImpl implements FlammableBlockRegistry {
 
 	@Override
 	public void add(Block block, Entry value) {
-		QuiltDeferringQueues.BLOCK.addEntry(QUEUE, block, value.toQuilt());
+		QuiltDeferringQueues.addEntry(BlockContentRegistries.FLAMMABLE_BLOCK, block, value.toQuilt());
 	}
 
 	@Override

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FlammableBlockRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FlammableBlockRegistryImpl.java
@@ -19,12 +19,12 @@ package net.fabricmc.fabric.impl.content.registry;
 
 import org.quiltmc.qsl.block.content.registry.api.BlockContentRegistries;
 import org.quiltmc.qsl.block.content.registry.api.FlammableBlockEntry;
+import org.quiltmc.quilted_fabric_api.impl.content.registry.util.QuiltDeferringQueues;
 
 import net.minecraft.block.Block;
 import net.minecraft.tag.TagKey;
 
 import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
 
 public class FlammableBlockRegistryImpl implements FlammableBlockRegistry {
 	private FlammableBlockRegistryImpl(Block key) { }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FuelRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FuelRegistryImpl.java
@@ -21,18 +21,20 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 
 import org.quiltmc.qsl.item.content.registry.api.ItemContentRegistries;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import net.minecraft.tag.TagKey;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
 
 import net.fabricmc.fabric.api.registry.FuelRegistry;
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
+import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
 
-// TODO: Clamp values to 32767 (+ add hook for mods which extend the limit to disable the check?)
+// Fabric To-Do: Clamp values to 32767 (+ add hook for mods which extend the limit to disable the check?)
+// About that, Quilt's equivalent API supports integer values properly, no need for that
 public final class FuelRegistryImpl implements FuelRegistry {
-	private static final Logger LOGGER = LoggerFactory.getLogger(FuelRegistryImpl.class);
+	private static final DeferringQueue<Item, Integer> QUEUE = QuiltDeferringQueues.ITEM.register(ItemContentRegistries.FUEL_TIME);
+	//private static final Logger LOGGER = LoggerFactory.getLogger(FuelRegistryImpl.class);
 
 	public FuelRegistryImpl() { }
 
@@ -51,19 +53,11 @@ public final class FuelRegistryImpl implements FuelRegistry {
 
 	@Override
 	public void add(ItemConvertible item, Integer cookTime) {
-		if (cookTime > 32767) {
-			LOGGER.warn("Tried to register an overly high cookTime: " + cookTime + " > 32767! (" + item + ")");
-		}
-
-		ItemContentRegistries.FUEL_TIME.put(item.asItem(), cookTime.intValue());
+		QuiltDeferringQueues.ITEM.addEntry(QUEUE, item.asItem(), cookTime.intValue());
 	}
 
 	@Override
 	public void add(TagKey<Item> tag, Integer cookTime) {
-		if (cookTime > 32767) {
-			LOGGER.warn("Tried to register an overly high cookTime: " + cookTime + " > 32767! (" + getTagName(tag) + ")");
-		}
-
 		ItemContentRegistries.FUEL_TIME.put(tag, cookTime.intValue());
 	}
 
@@ -88,10 +82,6 @@ public final class FuelRegistryImpl implements FuelRegistry {
 	}
 
 	public void apply(Map<Item, Integer> map) { }
-
-	private static String getTagName(TagKey<?> tag) {
-		return tag.id().toString();
-	}
 
 	public void resetCache() { }
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FuelRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FuelRegistryImpl.java
@@ -28,12 +28,10 @@ import net.minecraft.item.ItemConvertible;
 
 import net.fabricmc.fabric.api.registry.FuelRegistry;
 import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues.DeferringQueue;
 
 // Fabric To-Do: Clamp values to 32767 (+ add hook for mods which extend the limit to disable the check?)
 // About that, Quilt's equivalent API supports integer values properly, no need for that
 public final class FuelRegistryImpl implements FuelRegistry {
-	private static final DeferringQueue<Item, Integer> QUEUE = QuiltDeferringQueues.ITEM.register(ItemContentRegistries.FUEL_TIME);
 	//private static final Logger LOGGER = LoggerFactory.getLogger(FuelRegistryImpl.class);
 
 	public FuelRegistryImpl() { }
@@ -53,7 +51,7 @@ public final class FuelRegistryImpl implements FuelRegistry {
 
 	@Override
 	public void add(ItemConvertible item, Integer cookTime) {
-		QuiltDeferringQueues.ITEM.addEntry(QUEUE, item.asItem(), cookTime.intValue());
+		QuiltDeferringQueues.addEntry(ItemContentRegistries.FUEL_TIME, item.asItem(), cookTime.intValue());
 	}
 
 	@Override

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FuelRegistryImpl.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/FuelRegistryImpl.java
@@ -21,13 +21,13 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 
 import org.quiltmc.qsl.item.content.registry.api.ItemContentRegistries;
+import org.quiltmc.quilted_fabric_api.impl.content.registry.util.QuiltDeferringQueues;
 
 import net.minecraft.tag.TagKey;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
 
 import net.fabricmc.fabric.api.registry.FuelRegistry;
-import net.fabricmc.fabric.impl.content.registry.util.QuiltDeferringQueues;
 
 // Fabric To-Do: Clamp values to 32767 (+ add hook for mods which extend the limit to disable the check?)
 // About that, Quilt's equivalent API supports integer values properly, no need for that

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/util/QuiltDeferringQueues.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/util/QuiltDeferringQueues.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.quiltmc.loader.api.QuiltLoader;
+import org.quiltmc.qsl.base.api.util.TriState;
 import org.quiltmc.qsl.registry.api.event.RegistryMonitor;
 import org.quiltmc.qsl.registry.attachment.api.RegistryEntryAttachment;
 import org.slf4j.Logger;
@@ -14,22 +16,24 @@ import org.slf4j.LoggerFactory;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.world.event.GameEvent;
 
-// TODO - Clear this up
 public class QuiltDeferringQueues<T> {
+	private static final TriState CRASH_ON_DEFERRING_ENTRY = TriState.fromProperty("quilted_fabric_api.quilted_fabric_content_registries_v0.crash_on_deferring_entry");
 	private static final Logger LOGGER = LoggerFactory.getLogger("Quilted Fabric Content Registries");
 
 	private final List<DeferringQueue<T, ?>> queues = new ArrayList<>();
 	private boolean hasEvent = false;
-	
-	public static final QuiltDeferringQueues<Block> BLOCK_DEFERRING_QUEUES = new QuiltDeferringQueues<>();
-	public static final QuiltDeferringQueues<Item> ITEM_DEFERRING_QUEUES = new QuiltDeferringQueues<>();
+
+	public static final QuiltDeferringQueues<Block> BLOCK = new QuiltDeferringQueues<>();
+	public static final QuiltDeferringQueues<Item> ITEM = new QuiltDeferringQueues<>();
+	public static final QuiltDeferringQueues<GameEvent> GAME_EVENT = new QuiltDeferringQueues<>();
 
 	public QuiltDeferringQueues() {
 		this.hasEvent = false;
 	}
 
-	public <V> DeferringQueue<T, V> registerQueue(RegistryEntryAttachment<T, V> registryAttachment) {
+	public <V> DeferringQueue<T, V> register(RegistryEntryAttachment<T, V> registryAttachment) {
 		var queue = new DeferringQueue<>(registryAttachment, new HashMap<>());
 
 		queues.add(queue);
@@ -43,35 +47,64 @@ public class QuiltDeferringQueues<T> {
 			queue.deferredEntries().put(entry, value);
 
 			if (!hasEvent) {
-				this.createEvent(queue.registryAttachment().registry());
-				this.hasEvent = true;
+				if (CRASH_ON_DEFERRING_ENTRY.toBooleanOrElse(QuiltLoader.isDevelopmentEnvironment())) {
+					if (CRASH_ON_DEFERRING_ENTRY == TriState.DEFAULT) {
+						LOGGER.warn("A mod has attempted to put an unregistered entry to a Fabric API content registry (bridged to the "
+								+ queue.registryAttachment().id() + " registry attachment by QFAPI)! The game will proceed to crash."
+								+ "This debugging behavior may be disabled with the \"quilted_fabric_api.quilted_fabric_content_registries_v0.crash_on_deferring_entry\" property "
+								+ "set to false.");
+					} else {
+						LOGGER.warn("A mod has attempted to put an unregistered entry to a Fabric API content registry (bridged to the "
+								+ queue.registryAttachment().id() + " registry attachment by QFAPI)! The game will proceed to crash "
+								+ "due to a debug property being enabled.");
+					}
+
+					throw new UnsupportedOperationException();
+				} else {
+					LOGGER.warn("A mod has attempted to put an unregistered entry to a Fabric API content registry (bridged to the "
+							+ queue.registryAttachment().id() + " registry attachment by QFAPI)! The " + queue.registryAttachment().registry().toString()
+							+ " registry's deferring queue has been activated in order to re-route its addition to post-registration.");
+					this.createEvent(queue.registryAttachment().registry());
+					this.hasEvent = true;
+				}
 			}
 		} else {
 			queue.registryAttachment().put(entry, value);
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	public <V> void createEvent(Registry<T> registry) {
 		RegistryMonitor.create(registry).forUpcoming(entryAdded -> {
+			var queuesToRemove = new ArrayList<DeferringQueue<?, ?>>();
+
 			for (DeferringQueue<?, ?> queue : queues) {
 				var entriesToRemove = new ArrayList<>();
 
 				for (Entry<?, ?> entry: queue.deferredEntries().entrySet()) {
 					var castEntry = (Entry<T, V>) entry;
+
 					if (registry.getId((castEntry.getKey())).equals(entryAdded.id())) {
 						((RegistryEntryAttachment<T, V>) queue.registryAttachment()).put(castEntry.getKey(), castEntry.getValue());
 						entriesToRemove.add(entry.getKey());
-						LOGGER.warn("Registered the deffered entry " + entryAdded.id() + " to a content registry.");
+						LOGGER.warn("Registered the deferred entry " + entryAdded.id() + " to the Fabric API content registry bridged to QSL's "
+								+ queue.registryAttachment().id() + " registry attachment.");
 					}
 				}
 
 				entriesToRemove.forEach(entry -> queue.deferredEntries().remove(entry));
+
+				if (queue.deferredEntries().size() == 0) {
+					queuesToRemove.add(queue);
+				}
 			}
+
+			queuesToRemove.forEach(entry -> queues.remove(entry));
 		});
 	}
 
-	public static record DeferringQueue<T, V>(
-		RegistryEntryAttachment<T, V> registryAttachment,
-		Map<T, V> deferredEntries
-	) {}
+	public record DeferringQueue<T, V>(
+			RegistryEntryAttachment<T, V> registryAttachment,
+			Map<T, V> deferredEntries
+	) { }
 }

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/util/QuiltDeferringQueues.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/util/QuiltDeferringQueues.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.content.registry.util;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.quiltmc.qsl.base.api.util.TriState;
 import org.quiltmc.qsl.block.content.registry.api.ReversibleBlockEntry;
@@ -83,17 +98,21 @@ public class QuiltDeferringQueues<T> {
 
 	public static void updateOmniqueue() {
 		var entriesToRemove = new ArrayList<>();
+
 		for (var entry : OMNIQUEUE.entrySet()) {
 			var entriesToRemove2 = new ArrayList<>();
+
 			for (var listEntry : entry.getValue()) {
 				if (!isEntryDeferred(listEntry.entry()) && !isEntryDeferred(listEntry.value())) {
 					entry.getKey().put(listEntry.entry(), listEntry.value());
 					entriesToRemove2.add(listEntry.entry());
 				}
 			}
+
 			entry.getValue().removeAll(entriesToRemove2);
 			if (entry.getValue().size() == 0) entriesToRemove.add(entry.getKey());
 		}
+
 		entriesToRemove.forEach(entry -> OMNIQUEUE.remove(entry));
 	}
 
@@ -130,13 +149,16 @@ public class QuiltDeferringQueues<T> {
 			LOGGER.info("Event created for " + registry.toString());
 			RegistryMonitor.create(this.registry).forUpcoming(entryAdded -> {
 				var entriesToRemove = new ArrayList<>();
+
 				for (K entry : this.deferredEntries) {
 					LOGGER.warn("a: " + entryAdded.id());
 					LOGGER.warn("b: " + this.registry.getId(entry));
+
 					if (entryAdded.id().equals(this.registry.getId(entry))) {
 						entriesToRemove.add(entry);
 					}
 				}
+
 				this.deferredEntries.removeAll(entriesToRemove);
 				// TODO - Check if the deferred entries list has changed; Yes, it's very easy to do that, but I actually need to debug stuff before doing that
 				updateOmniqueue();

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/util/QuiltDeferringQueues.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/util/QuiltDeferringQueues.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.content.registry.util;
 
 import java.util.ArrayList;

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/util/QuiltDeferringQueues.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/util/QuiltDeferringQueues.java
@@ -1,0 +1,77 @@
+package net.fabricmc.fabric.impl.content.registry.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.quiltmc.qsl.registry.api.event.RegistryMonitor;
+import org.quiltmc.qsl.registry.attachment.api.RegistryEntryAttachment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.util.registry.Registry;
+
+// TODO - Clear this up
+public class QuiltDeferringQueues<T> {
+	private static final Logger LOGGER = LoggerFactory.getLogger("Quilted Fabric Content Registries");
+
+	private final List<DeferringQueue<T, ?>> queues = new ArrayList<>();
+	private boolean hasEvent = false;
+	
+	public static final QuiltDeferringQueues<Block> BLOCK_DEFERRING_QUEUES = new QuiltDeferringQueues<>();
+	public static final QuiltDeferringQueues<Item> ITEM_DEFERRING_QUEUES = new QuiltDeferringQueues<>();
+
+	public QuiltDeferringQueues() {
+		this.hasEvent = false;
+	}
+
+	public <V> DeferringQueue<T, V> registerQueue(RegistryEntryAttachment<T, V> registryAttachment) {
+		var queue = new DeferringQueue<>(registryAttachment, new HashMap<>());
+
+		queues.add(queue);
+
+		return queue;
+	}
+
+	public <V> void addEntry(DeferringQueue<T, V> queue, T entry, V value) {
+		if (queue.registryAttachment().registry().getKey(entry).isEmpty()) {
+			LOGGER.warn("There was an attempt to add an unregistered item to a content registry! The registration will be deferred to a later point.");
+			queue.deferredEntries().put(entry, value);
+
+			if (!hasEvent) {
+				this.createEvent(queue.registryAttachment().registry());
+				this.hasEvent = true;
+			}
+		} else {
+			queue.registryAttachment().put(entry, value);
+		}
+	}
+
+	public <V> void createEvent(Registry<T> registry) {
+		RegistryMonitor.create(registry).forUpcoming(entryAdded -> {
+			for (DeferringQueue<?, ?> queue : queues) {
+				var entriesToRemove = new ArrayList<>();
+
+				for (Entry<?, ?> entry: queue.deferredEntries().entrySet()) {
+					var castEntry = (Entry<T, V>) entry;
+					if (registry.getId((castEntry.getKey())).equals(entryAdded.id())) {
+						((RegistryEntryAttachment<T, V>) queue.registryAttachment()).put(castEntry.getKey(), castEntry.getValue());
+						entriesToRemove.add(entry.getKey());
+						LOGGER.warn("Registered the deffered entry " + entryAdded.id() + " to a content registry.");
+					}
+				}
+
+				entriesToRemove.forEach(entry -> queue.deferredEntries().remove(entry));
+			}
+		});
+	}
+
+	public static record DeferringQueue<T, V>(
+		RegistryEntryAttachment<T, V> registryAttachment,
+		Map<T, V> deferredEntries
+	) {}
+}

--- a/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/util/QuiltDeferringQueues.java
+++ b/fabric-content-registries-v0/src/main/java/net/fabricmc/fabric/impl/content/registry/util/QuiltDeferringQueues.java
@@ -181,9 +181,5 @@ public class QuiltDeferringQueues<T> {
 		}
 	}
 
-	public static class DisabledDeferringQueueException extends RuntimeException {
-		public DisabledDeferringQueueException() {
-			super();
-		}
-	}
+	public static class DisabledDeferringQueueException extends RuntimeException { }
 }

--- a/fabric-content-registries-v0/src/main/java/org/quiltmc/quilted_fabric_api/impl/content/registry/util/QuiltDeferringQueues.java
+++ b/fabric-content-registries-v0/src/main/java/org/quiltmc/quilted_fabric_api/impl/content/registry/util/QuiltDeferringQueues.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.fabricmc.fabric.impl.content.registry.util;
+package org.quiltmc.quilted_fabric_api.impl.content.registry.util;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
This PR fixes crashes (such as the one in #31) that involve the bad practice of using an unregistered entry on the registration of a pair in a content registry through a deferring queue system that defers those registrations to only after the relevant entries are registered.

This PR also adds the `quilted_fabric_api.quilted_fabric_content_registries_v0.crash_on_deferring_entry` property, which when enabled (by default, if it's a dev environment, it's enabled, else, disabled), will crash if a deferred queue is activated, allowing for an easier time finding out which mod was responsible for using an unregistered entry

Modders are still encouraged to fix the issue on their side, especially since the deferred queues may have a performance impact and plus, these are unregistered entries, they can and will cause trouble eventually, Quilt or not.

...oh right, github does not accept indirectness (which is fair enough); *ahem*, fixes #31 