### PR TITLE
update loader to `0.18.1-beta.76`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ version=5.0.0-beta.6
 upstream_version=0.74.0
 minecraft_version=1.19.3
 yarn_version=+build.3
-loader_version=0.17.11
+loader_version=0.18.1-beta.76
 qsl_version=4.0.0-beta.11+1.19.3
 installer_version=0.11.1
 


### PR DESCRIPTION
appears to have not broken anything. I'm pretty sure.

notes:
fixes #68 