### PR TITLE
Add synthetic resource reloader order injection

### DIFF
--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
@@ -49,6 +49,10 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 		ResourceLoader resourceLoader = ResourceLoader.get(this.type);
 		resourceLoader.registerReloader(listener);
 
+		// Inject a synthetic ordering between listeners registered on the same namespace that are registered after each other
+		// This matches the existing behavior of fabric-api where listeners are called in registration order, fixing some compatibility issues.
+		// We split on namespaces to prevent grouping all fabric based listeners into one long chain and causing potential issues in actual ordering.
+		// see i.e https://gitlab.com/cable-mc/cobblemon/-/issues/148 or https://github.com/apace100/calio/issues/3
 		if (
 				lastResourceReloaderIdentifier != null
 						&& Objects.equals(lastResourceReloaderIdentifier.getNamespace(), listener.getQuiltId().getNamespace())

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
@@ -33,6 +33,7 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 	private static final Map<ResourceType, ResourceManagerHelperImpl> registryMap = new HashMap<>();
 
 	private final ResourceType type;
+
 	private Identifier lastResourceReloaderIdentifier = null;
 
 	private ResourceManagerHelperImpl(ResourceType type) {

--- a/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
+++ b/fabric-resource-loader-v0/src/main/java/net/fabricmc/fabric/impl/resource/loader/ResourceManagerHelperImpl.java
@@ -19,10 +19,12 @@ package net.fabricmc.fabric.impl.resource.loader;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.quiltmc.qsl.resource.loader.api.ResourceLoader;
 
 import net.minecraft.resource.ResourceType;
+import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
@@ -31,6 +33,7 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 	private static final Map<ResourceType, ResourceManagerHelperImpl> registryMap = new HashMap<>();
 
 	private final ResourceType type;
+	private Identifier lastResourceReloaderIdentifier = null;
 
 	private ResourceManagerHelperImpl(ResourceType type) {
 		this.type = type;
@@ -42,6 +45,16 @@ public class ResourceManagerHelperImpl implements ResourceManagerHelper {
 
 	@Override
 	public void registerReloadListener(IdentifiableResourceReloadListener listener) {
-		ResourceLoader.get(this.type).registerReloader(listener);
+		ResourceLoader resourceLoader = ResourceLoader.get(this.type);
+		resourceLoader.registerReloader(listener);
+
+		if (
+				lastResourceReloaderIdentifier != null
+						&& Objects.equals(lastResourceReloaderIdentifier.getNamespace(), listener.getQuiltId().getNamespace())
+		) {
+			resourceLoader.addReloaderOrdering(lastResourceReloaderIdentifier, listener.getQuiltId());
+		}
+
+		lastResourceReloaderIdentifier = listener.getQuiltId();
 	}
 }


### PR DESCRIPTION
This fixes issues with both cobblemon (see https://gitlab.com/cable-mc/cobblemon/-/issues/148) as well as issues similar to old origins (see https://github.com/apace100/calio/issues/3) without requiring changes on behalf of those mods by making the implicit ordering of fabric resource loaders (registration order) explicit instead by adapting it to the proper ordering system in the shim layer.

Stress tested with the following mod set and found no issues (cobblemon was slightly modified to add some debug messages, otherwise no changes from release)
![image](https://user-images.githubusercontent.com/52360088/223936814-85f1e0c1-577b-4eba-8edc-3dc585c0340e.png)

I opted to split ordering chains on namespaces since it seemed less likely to cause issues, and it shouldnt be possible for an implicit ordering like that to be relied on anyways due to mod load order randomization. (unless someone is using multiple mod ids in their mod but that seems like an incredibly rare edge case)

This code could cause duplicated reloader order constraints, but as far as I can tell that would only waste a few bytes of memory and maybe a couple cycles at sort time