### PR TITLE
Hopefully fix machete plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 	id "com.matthewprenger.cursegradle" version "1.4.0"
 	id "com.modrinth.minotaur" version "2.5.0"
 	id "me.modmuss50.remotesign" version "0.4.0" apply false
-	//id "io.github.p03w.machete" version "1.2.0"
+	id "io.github.p03w.machete" version "2.0.1"
 }
 
 def ENV = System.getenv()
@@ -632,14 +632,14 @@ remapJar {
 	}
 }
 
-/*
+
 machete {
 	// JSON minification isn't effective on this scale and sacrifices readability
 	json.enabled = false
+	ignoredTasks.add("jar")
+	additionalTasks.add("remapJar")
 }
-// This prevents issues with execution optimizations and therefore, Gradle deprecation warnings
-tasks.prepareRemapJar.dependsOn('optimizeOutputsOfJar')
-*/
+tasks.remapJar.finalizedBy('optimizeOutputsOfRemapJar')
 
 tasks.register('renameJar', Jar) {
 	dependsOn signingEnabled ? signRemapJar : remapJar
@@ -651,7 +651,6 @@ tasks.register('renameJar', Jar) {
 	def upstream_fapi_version_normalized = project.upstream_version
 	archiveFileName.set("qfapi-${qfapi_version_normalized}_qsl-${qsl_version_normalized}_fapi-${upstream_fapi_version_normalized}_mc-${project.minecraft_version}.jar")
 }
-//tasks.renameJar.dependsOn('optimizeOutputsOfJar')
 
 curseforge {
 	if (ENV.CURSEFORGE_TOKEN) {

--- a/build.gradle
+++ b/build.gradle
@@ -500,11 +500,28 @@ subprojects {
 	javadoc.enabled = false
 }
 
+machete {
+	// JSON minification isn't effective on this scale and sacrifices readability
+	json.enabled = false
+	finalizeAfter = ""
+	ignoredTasks.add("jar")
+	additionalTasks.add("remapJar")
+}
+if (signingEnabled) {
+	tasks.signRemapJar.finalizedBy('optimizeOutputsOfRemapJar')
+} else {
+	tasks.remapJar.finalizedBy('optimizeOutputsOfRemapJar')
+}
+
+tasks.register('optimizedJar') {
+	dependsOn 'optimizeOutputsOfRemapJar'
+}
+
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
 			artifact(signingEnabled ? signRemapJar.output : remapJar) {
-				builtBy(signingEnabled ? signRemapJar : remapJar)
+				builtBy(tasks.named('optimizedJar'))
 			}
 
 			artifact(sourcesJar) {
@@ -619,8 +636,8 @@ java.util.stream.Stream<ResolvedDependency> getAllQslModules() {
 			throw RuntimeException("Unexpected dependency: $it")
 		}
 	}
-
 }
+
 remapJar {
 	afterEvaluate {
 		subprojects.each {
@@ -632,17 +649,8 @@ remapJar {
 	}
 }
 
-
-machete {
-	// JSON minification isn't effective on this scale and sacrifices readability
-	json.enabled = false
-	ignoredTasks.add("jar")
-	additionalTasks.add("remapJar")
-}
-tasks.remapJar.finalizedBy('optimizeOutputsOfRemapJar')
-
 tasks.register('renameJar', Jar) {
-	dependsOn signingEnabled ? signRemapJar : remapJar
+	dependsOn 'optimizedJar'
 
 	with remapJar
 	from zipTree(remapJar.archiveFile)
@@ -678,12 +686,7 @@ curseforge {
 	}
 }
 tasks.curseforge.dependsOn renameJar
-
-if (signingEnabled) {
-	project.tasks.curseforge.dependsOn signRemapJar
-	project.tasks.modrinth.dependsOn signRemapJar
-	build.dependsOn signRemapJar
-}
+tasks.build.dependsOn optimizeJar
 
 import org.kohsuke.github.GHReleaseBuilder
 import org.kohsuke.github.GitHub

--- a/build.gradle
+++ b/build.gradle
@@ -686,7 +686,7 @@ curseforge {
 	}
 }
 tasks.curseforge.dependsOn renameJar
-tasks.build.dependsOn optimizeJar
+tasks.build.dependsOn optimizedJar
 
 import org.kohsuke.github.GHReleaseBuilder
 import org.kohsuke.github.GitHub


### PR DESCRIPTION
Hopefully, this fix will let the machete plugin work again to make optimized, smaller jar files - this fix was lifted out of the wackiness I have to do to get GroovyDuvet to work.

Note: I have not tested this as extensively as I might like, because I could not figure out the proper way to build it locally - `./gradlew build` errors out on the repo without any of my changes due to datagen stuff. I tested this with `./gradlew remapJar`, however, and it properly generated and compressed the remapped jar.