### PR TITLE
Invert wasDeath -> alive translation

### DIFF
--- a/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
+++ b/fabric-entity-events-v1/src/main/java/net/fabricmc/fabric/api/entity/event/v1/ServerPlayerEvents.java
@@ -38,8 +38,8 @@ public final class ServerPlayerEvents {
 	 */
 	public static final Event<ServerPlayerEvents.CopyFrom> COPY_FROM = QuiltCompatEvent.fromQuilt(
 			org.quiltmc.qsl.entity.event.api.ServerPlayerEntityCopyCallback.EVENT,
-			playerCopyCallback -> (copy, original, wasDeath) -> playerCopyCallback.copyFromPlayer(original, copy, wasDeath),
-			invokerGetter -> (oldPlayer, newPlayer, alive) -> invokerGetter.get().onPlayerCopy(newPlayer, oldPlayer, alive)
+			playerCopyCallback -> (copy, original, wasDeath) -> playerCopyCallback.copyFromPlayer(original, copy, !wasDeath),
+			invokerGetter -> (oldPlayer, newPlayer, alive) -> invokerGetter.get().onPlayerCopy(newPlayer, oldPlayer, !alive)
 	);
 
 	/**


### PR DESCRIPTION
# This PR
This PR inverts the QSL `wasDeath` flag when translating it into FAPI `alive` flag in the `ServerPlayerEvents.CopyFrom` event. The FAPI `alive` flag indicates whether the old player is still alive. The QSL `wasDeath` flag indicates whether the copy was due to the old player dying. Generally, these two flags should be opposites of each other.

# Testing
I have tested this PR with the Soulbound Enchantments mod (which is how I discovered this bug in the first place) and inverting this flag fixes the issues I was experiencing.