### PR TITLE
Fix dependency name in deprecated/build.gradle

### DIFF
--- a/deprecated/build.gradle
+++ b/deprecated/build.gradle
@@ -26,7 +26,7 @@ publishing {
 				// Depend on the main project.
 				def depNode = depsNode.appendNode("dependency")
 				depNode.appendNode("groupId", group)
-				depNode.appendNode("artifactId", "fabric-api")
+				depNode.appendNode("artifactId", "quilted-fabric-api")
 				depNode.appendNode("version", version)
 				depNode.appendNode("scope", "compile")
 			}


### PR DESCRIPTION
The `build.gradle` in the deprecated directory was incorrectly trying to depend on the main project using `fabric-api` instead of `quilted-fabric-api`. This was causing build errors when trying include the `quilted-fabric-api` into projects. This changes has been present on most branches but is missing on `1.20.6` and `1.21`