### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: Logs
       description: |
-        If applicable (crash, error output in console), please provide your crash report or latest.log
+        Please provide your crash report or latest.log.
         To upload logs, use [MCLogs](https://mclo.gs/) to upload your crashlog or latest.log. If you are unsure of how to obtain a crash report, read [here](https://minecraft.wiki/w/Tutorials/Obtaining_a_crash_report).
         Crash reports without a crashlog or a latest.log file will be marked as invalid. Crashes are hard to fix without the crashlogs or latest.log file(s).
     validations:

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -1,0 +1,38 @@
+name: Crash Report
+description: Create a crash report to receive support for a breaking issue.
+labels: [support, crash]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking your time to report this crash! If you need real-time help, join us on [Discord](https://discord.quiltmc.org).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the crash
+      description: "Describe the crash as clearly as possible. The more detail you provide means the sooner you can get back to your game! This includes: steps to reproduce or situation right before the crash, recent changes you made to your mods list, or any additional context that could be helpful."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Which environment crashed?
+      options:
+        - Client
+        - Server
+        - Both
+    validations:
+      required: true
+
+  - type: input
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        If applicable (crash, error output in console), please provide your crash report or latest.log
+        To upload logs, use [MCLogs](https://mclo.gs/) to upload your crashlog or latest.log. If you are unsure of how to obtain a crash report, read [here](https://minecraft.wiki/w/Tutorials/Obtaining_a_crash_report).
+        Crash reports without a crashlog or a latest.log file will be marked as invalid. Crashes are hard to fix without the crashlogs or latest.log file(s).
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/diverging_behavior.yml
+++ b/.github/ISSUE_TEMPLATE/diverging_behavior.yml
@@ -1,0 +1,43 @@
+name: QFAPI/FAPI Behavior Divergence Report
+description: Create a report to help us fix behavior divergences between Quilted Fabric API and Fabric API.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking your time to report QFAPI behavioral divergences! If you need real-time help, join us on [Discord](https://discord.quiltmc.org).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the behavior divergence
+      description: "Describe the divergence as clearly as possible. The more detail you provide means the sooner the divergence can be fixed! This includes: steps to reproduce or situation you encountered the divergence in, recent changes you made to your mods list, or any additional context that could be helpful."
+    validations:
+      required: true
+
+  - type: textarea
+    id: where-in-qsl
+    attributes:
+      label: How did QFAPI's behavior diverge from FAPI's behavior?
+      description: "If possible, please provide a GitHub link to the section of QFAPI that diverged from FAPI?"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Which environment did you encounter this divergence in?
+      options:
+        - Client
+        - Server
+        - Both
+    validations:
+      required: true
+
+  - type: input
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        If applicable, please provide your crash report or latest.log
+        To upload logs, use [MCLogs](https://mclo.gs/) to upload your latest.log. If you are unsure of how to obtain a log, read [here](https://minecraft.wiki/w/Tutorials/Obtaining_a_crash_report).

--- a/.github/ISSUE_TEMPLATE/game_issue.yml
+++ b/.github/ISSUE_TEMPLATE/game_issue.yml
@@ -1,5 +1,5 @@
 name: Game Issue
-description: Create a "game issue" report to receive support for a non-crashing issue.
+description: Create a report for a non-crashing issue.
 labels: [support, bug]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/game_issue.yml
+++ b/.github/ISSUE_TEMPLATE/game_issue.yml
@@ -1,0 +1,35 @@
+name: Game Issue
+description: Create a "game issue" report to receive support for a non-crashing issue.
+labels: [support, bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking your time to report the game issue you encountered! If you need real-time help, join us on [Discord](https://discord.quiltmc.org).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the issue
+      description: "Describe the issue as clearly as possible. The more detail you provide means the sooner the issue can be fixed! This includes: steps to reproduce or situation you encountered the issue in, recent changes you made to your mods list, or any additional context that could be helpful."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Which environment did you encounter this issue in?
+      options:
+        - Client
+        - Server
+        - Both
+    validations:
+      required: true
+
+  - type: input
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        If applicable, please provide your latest.log
+        To upload logs, use [MCLogs](https://mclo.gs/) to upload your latest.log.


### PR DESCRIPTION
issue templates were ported from https://github.com/QuiltMC/quilt-standard-libraries/pull/380 with some edits made to them so they fit the QFAPI repo